### PR TITLE
Remove abstraction-breaking Reader accession

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     include_package_data=True,
     zip_safe = False,
     install_requires=[
-        'pbcore >= 1.2.6',
+        'pbcore >= 1.2.8',
         'pbcommand >= 0.2.0',
         'numpy >= 1.6.0',
         'h5py >= 2.0.1',


### PR DESCRIPTION
The previous implementation went through each resource reader in the current
AlignmentSet, assembling tStart tEnd pairs for relevant subreads. Now that a
pbi (or cmp.h5) file is a requirement for using GenomicConsensus and a due to a few DataSet
API improvements, we no longer have to break this abstraction.

Instead, we do a few pbindex table queries and we're done.

@dalexander: Let me know if this is ok with you. 