### PR TITLE
update for new pbcommand 0.3.17 logging behavior

### DIFF
--- a/GenomicConsensus/Worker.py
+++ b/GenomicConsensus/Worker.py
@@ -81,7 +81,7 @@ class Worker(object):
 
 
     def run(self):
-        if options.debug:
+        if options.pdb:
             import ipdb
             with ipdb.launch_ipdb_on_exception():
                 self._run()

--- a/GenomicConsensus/main.py
+++ b/GenomicConsensus/main.py
@@ -35,12 +35,13 @@ from __future__ import absolute_import
 
 import argparse, atexit, cProfile, gc, glob, h5py, logging, multiprocessing
 import os, pstats, random, shutil, tempfile, time, threading, Queue, traceback
+import functools
 import re
 import sys
 
 import pysam
 
-from pbcommand.utils import setup_log
+from pbcommand.utils import setup_log, Constants as LogFormats
 from pbcommand.cli import pbparser_runner
 from pbcore.io import AlignmentSet, ContigSet
 
@@ -394,13 +395,15 @@ def resolved_tool_contract_runner(resolved_contract):
     return rc
 
 def main(argv=sys.argv):
+    setup_log_ = functools.partial(setup_log,
+        str_formatter=LogFormats.LOG_FMT_LVL)
     return pbparser_runner(
         argv=argv[1:],
         parser=get_parser(),
         args_runner_func=args_runner,
         contract_runner_func=resolved_tool_contract_runner,
         alog=logging.getLogger(),
-        setup_log_func=setup_log)
+        setup_log_func=setup_log_)
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/GenomicConsensus/main.py
+++ b/GenomicConsensus/main.py
@@ -70,18 +70,6 @@ class ToolRunner(object):
         self._algorithmConfiguration = None
         self._aborting = False
 
-    def _setupLogging(self):
-        if options.quiet:
-            logLevel = logging.ERROR
-        elif options.verbosity >= 2:
-            logLevel = logging.DEBUG
-        elif options.verbosity == 1:
-            logLevel = logging.INFO
-        else:
-            logLevel = logging.WARNING
-        log = logging.getLogger()
-        log.setLevel(logLevel)
-
     def _makeTemporaryDirectory(self):
         """
         Make a temp dir where we can stash things if necessary.
@@ -271,7 +259,6 @@ class ToolRunner(object):
         gc.disable()
 
         self._algorithm = self._algorithmByName(options.algorithm)
-        self._setupLogging()
         random.seed(42)
 
         logging.info("h5py version: %s" % h5py.version.version)
@@ -321,7 +308,7 @@ class ToolRunner(object):
                                 filename=os.path.join(options.temporaryDirectory,
                                                       "profile-main.out"))
 
-            elif options.debug:
+            elif options.pdb:
                 if not options.threaded:
                     die("Debugging only works with -T (threaded) mode")
                 logging.info("PID: %d", os.getpid())
@@ -407,18 +394,14 @@ def resolved_tool_contract_runner(resolved_contract):
     return rc
 
 def main(argv=sys.argv):
-    logFormat = '[%(levelname)s] %(message)s'
-    logging.basicConfig(level=logging.WARN, format=logFormat)
-    log = logging.getLogger()
-    def dummy_setup(*args, **kwargs):
-        pass
+    logging.basicConfig(level=logging.WARN)
     return pbparser_runner(
         argv=argv[1:],
         parser=get_parser(),
         args_runner_func=args_runner,
         contract_runner_func=resolved_tool_contract_runner,
-        alog=log,
-        setup_log_func=dummy_setup)
+        alog=logging.getLogger(),
+        setup_log_func=setup_log)
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/GenomicConsensus/main.py
+++ b/GenomicConsensus/main.py
@@ -394,7 +394,6 @@ def resolved_tool_contract_runner(resolved_contract):
     return rc
 
 def main(argv=sys.argv):
-    logging.basicConfig(level=logging.WARN)
     return pbparser_runner(
         argv=argv[1:],
         parser=get_parser(),

--- a/GenomicConsensus/options.py
+++ b/GenomicConsensus/options.py
@@ -51,9 +51,9 @@ from __future__ import absolute_import
 import argparse, h5py, os, os.path, sys, json
 
 from pbcommand.models import FileTypes, SymbolTypes, get_pbparser
-from pbcommand.common_options import (add_resolved_tool_contract_option,)
-# FIXME                                     add_subcomponent_versions_option)
-from pbcommand.cli import get_default_argparser
+from pbcommand.common_options import (add_resolved_tool_contract_option,
+                                      add_debug_option)
+# FIXME                               add_subcomponent_versions_option)
 
 from .utils import fileFormat
 from . import __VERSION__
@@ -103,7 +103,8 @@ def get_parser():
         description="Compute genomic consensus and call variants relative to the reference.",
         driver_exe=Constants.DRIVER_EXE,
         nproc=SymbolTypes.MAX_NPROC,
-        resource_types=())
+        resource_types=(),
+        default_level="WARN")
     tcp = p.tool_contract_parser
     tcp.add_input_file_type(FileTypes.DS_ALIGN, "infile",
         "Alignment DataSet", "BAM or Alignment DataSet")
@@ -328,16 +329,7 @@ def add_options_to_argument_parser(parser):
              "which selects the best parameter set from the cmp.h5")
 
     debugging = parser.add_argument_group("Verbosity and debugging/profiling")
-    debugging.add_argument(
-        "--verbose",
-        dest="verbosity",
-        action="count",
-        help="Set the verbosity level.")
-    debugging.add_argument(
-        "--quiet",
-        dest="quiet",
-        action="store_true",
-        help="Turn off all logging, including warnings")
+    add_debug_option(debugging)
     debugging.add_argument(
         "--profile",
         action="store_true",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     zip_safe = False,
     install_requires=[
         'pbcore >= 1.2.8',
-        'pbcommand >= 0.2.0',
+        'pbcommand >= 0.3.17',
         'numpy >= 1.6.0',
         'h5py >= 2.0.1',
         'ConsensusCore >= 1.0.1'


### PR DESCRIPTION
1. Adopt standardized options - all except --log-file are mutually exclusive:

      --log-file LOG_FILE   Write the log to file. Default(None) will write to
                            stdout. (default: None)
      --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                            Set log level (default: WARN)
      --debug               Alias for setting log level to DEBUG (default: False)
      --quiet               Alias for setting log level to CRITICAL to suppress
                            output. (default: False)
      -v, --verbose         Set the verbosity level. (default: None)

2. Use pbcommand.utils.setup_log, keeping default logging level of WARN.

3. The old --debug is replaced by --pdb.